### PR TITLE
Update jetty version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.0.6.v20130930</version>
+				<version>9.2.7.v20150116</version>
 				<configuration>
 					<webApp>
 						<contextPath>/${project.artifactId}</contextPath>


### PR DESCRIPTION
The current version of the jetty server prevents the resource view to render blank nodes. Here's a stack trace related to the problem:

```
org.apache.jasper.JasperException: javax.el.ELException: java.lang.IllegalAccessException: Class javax.el.BeanELResolver can not access a member of class java.util.HashMap$KeySet with modifiers "public"
  at org.apache.jasper.servlet.JspServletWrapper.service(JspServletWrapper.java:432)
  at org.apache.jasper.servlet.JspServlet.serviceJspFile(JspServlet.java:492)
  at org.apache.jasper.servlet.JspServlet.service(JspServlet.java:378)
  at javax.servlet.http.HttpServlet.service(HttpServlet.java:848)
  at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:698)
...
Caused by:
javax.el.ELException: java.lang.IllegalAccessException: Class javax.el.BeanELResolver can not access a member of class java.util.HashMap$KeySet with modifiers "public"
  at javax.el.BeanELResolver.invokeMethod(BeanELResolver.java:781)
  at javax.el.BeanELResolver.invoke(BeanELResolver.java:528)
  at javax.el.CompositeELResolver.invoke(CompositeELResolver.java:257)
  at com.sun.el.parser.AstValue.getValue(AstValue.java:134)
  at com.sun.el.parser.AstValue.getValue(AstValue.java:183)
...
Caused by:
java.lang.IllegalAccessException: Class javax.el.BeanELResolver can not access a member of class java.util.HashMap$KeySet with modifiers "public"
  at sun.reflect.Reflection.ensureMemberAccess(Reflection.java:110)
  at java.lang.reflect.AccessibleObject.slowCheckMemberAccess(AccessibleObject.java:262)
  at java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:254)
  at java.lang.reflect.Method.invoke(Method.java:599)
  at javax.el.BeanELResolver.invokeMethod(BeanELResolver.java:779)
```

Quickest way to reproduce, IMO:

* Set up a SPARQL server on localhost.
* Upload [this model](https://github.com/attadanta/LodView/blob/02baedc32597d2a16bc77b689ea170e0db6faa12/src/test/resources/models/observation.ttl) to the default graph and adjust `conf.ttl` accordingly.
* Start LodView with `mvn jetty:run`.
* Navigate to the following resource: `http://dareed.eu/node/4/interior/buildingMonitor/SANLUIS/observation/activeEnergy_4_f812ba67006f4a13aec3e181e6b48128`.

The proposed jetty version is the last one supporting java 1.7, as can be verified on [this page](http://www.eclipse.org/jetty/documentation/current/what-jetty-version.html).