### PR TITLE
Provide Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: java
 sudo: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ deploy:
   provider: releases
   api_key:
     secure: eWWzjthOJxgVcJmOZdZNv7nuMyIcp4Yyqt8EvajN27nkIeNg1QsQ1WZ87jhlXWo9X/2fB5WlO1Bmjct/G79PxL8oD3TH2fVN9tHpW4+wloN+kPodWedhDlyrG8oZtBewER1l5fzGoc7yV+I+USNuSmNTXB1uUDyEFs242fp7kKMy927tN0+MsZfsgj97BP+GdLgNdLUdovK4kvApj0QWvAlbDmHXrhzGiLk/2LVBfSJuo6FZ8TU2UpD7WwilvnccQG8KCbd6fzmpS9aL2L+D9dA0capSGqSA5q5IVeoBfampEoHO0IRS+fU90vXxWTxbt3SfTpN3lQbE6Am95+/78psV+Rc/s0NPm0L/VKg4gnDQyx3V7tjV53D5Z7CqXRiTaVe/R+ZAAJgvtokjbrHcwbXfHdIsX/66dIhOg468q1Ql10ZDe9JjvidN2tFRvGojuf9FY9+qITl0qzQnWR9EU264tl7RuxXc/QNQLyCRKpCJcAmUAxYVuTK9mBZQD+RZy4gtsX2YvyT6QDrLiDLeL9AC7An3MOHVbGUjQj6SUGhRxf/qeCg/hQ6JeCcI2oouZeYPQaDbKaf68xIA5n/gVvFcQy8fGLT/0aY9pCHqhBFzKGSGgkw6/eMTAaIKUop1yd9hGiFpiAC6msMNk5sTNi6yqqEnokgSY7grRkQQ+KE=
-  file: $TRAVIS_BUILD_DIR/target/lodview.war
+  file: /home/travis/build/zazukoians/LodView/target/lodview.war
   on:
     repo: zazukoians/LodView

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: java
 sudo: false
-
+script: mvn compile war:war
+deploy:
+  provider: releases
+  api_key:
+    secure: eWWzjthOJxgVcJmOZdZNv7nuMyIcp4Yyqt8EvajN27nkIeNg1QsQ1WZ87jhlXWo9X/2fB5WlO1Bmjct/G79PxL8oD3TH2fVN9tHpW4+wloN+kPodWedhDlyrG8oZtBewER1l5fzGoc7yV+I+USNuSmNTXB1uUDyEFs242fp7kKMy927tN0+MsZfsgj97BP+GdLgNdLUdovK4kvApj0QWvAlbDmHXrhzGiLk/2LVBfSJuo6FZ8TU2UpD7WwilvnccQG8KCbd6fzmpS9aL2L+D9dA0capSGqSA5q5IVeoBfampEoHO0IRS+fU90vXxWTxbt3SfTpN3lQbE6Am95+/78psV+Rc/s0NPm0L/VKg4gnDQyx3V7tjV53D5Z7CqXRiTaVe/R+ZAAJgvtokjbrHcwbXfHdIsX/66dIhOg468q1Ql10ZDe9JjvidN2tFRvGojuf9FY9+qITl0qzQnWR9EU264tl7RuxXc/QNQLyCRKpCJcAmUAxYVuTK9mBZQD+RZy4gtsX2YvyT6QDrLiDLeL9AC7An3MOHVbGUjQj6SUGhRxf/qeCg/hQ6JeCcI2oouZeYPQaDbKaf68xIA5n/gVvFcQy8fGLT/0aY9pCHqhBFzKGSGgkw6/eMTAaIKUop1yd9hGiFpiAC6msMNk5sTNi6yqqEnokgSY7grRkQQ+KE=
+  file: target/lodview.war
+  on:
+    repo: zazukoians/LodView

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ deploy:
   provider: releases
   api_key:
     secure: eWWzjthOJxgVcJmOZdZNv7nuMyIcp4Yyqt8EvajN27nkIeNg1QsQ1WZ87jhlXWo9X/2fB5WlO1Bmjct/G79PxL8oD3TH2fVN9tHpW4+wloN+kPodWedhDlyrG8oZtBewER1l5fzGoc7yV+I+USNuSmNTXB1uUDyEFs242fp7kKMy927tN0+MsZfsgj97BP+GdLgNdLUdovK4kvApj0QWvAlbDmHXrhzGiLk/2LVBfSJuo6FZ8TU2UpD7WwilvnccQG8KCbd6fzmpS9aL2L+D9dA0capSGqSA5q5IVeoBfampEoHO0IRS+fU90vXxWTxbt3SfTpN3lQbE6Am95+/78psV+Rc/s0NPm0L/VKg4gnDQyx3V7tjV53D5Z7CqXRiTaVe/R+ZAAJgvtokjbrHcwbXfHdIsX/66dIhOg468q1Ql10ZDe9JjvidN2tFRvGojuf9FY9+qITl0qzQnWR9EU264tl7RuxXc/QNQLyCRKpCJcAmUAxYVuTK9mBZQD+RZy4gtsX2YvyT6QDrLiDLeL9AC7An3MOHVbGUjQj6SUGhRxf/qeCg/hQ6JeCcI2oouZeYPQaDbKaf68xIA5n/gVvFcQy8fGLT/0aY9pCHqhBFzKGSGgkw6/eMTAaIKUop1yd9hGiFpiAC6msMNk5sTNi6yqqEnokgSY7grRkQQ+KE=
-  file: target/lodview.war
+  file: $TRAVIS_BUILD_DIR/target/lodview.war
   on:
     repo: zazukoians/LodView

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 script: mvn compile war:war
 deploy:
   provider: releases
+  skip_cleanup: true
   api_key:
     secure: eWWzjthOJxgVcJmOZdZNv7nuMyIcp4Yyqt8EvajN27nkIeNg1QsQ1WZ87jhlXWo9X/2fB5WlO1Bmjct/G79PxL8oD3TH2fVN9tHpW4+wloN+kPodWedhDlyrG8oZtBewER1l5fzGoc7yV+I+USNuSmNTXB1uUDyEFs242fp7kKMy927tN0+MsZfsgj97BP+GdLgNdLUdovK4kvApj0QWvAlbDmHXrhzGiLk/2LVBfSJuo6FZ8TU2UpD7WwilvnccQG8KCbd6fzmpS9aL2L+D9dA0capSGqSA5q5IVeoBfampEoHO0IRS+fU90vXxWTxbt3SfTpN3lQbE6Am95+/78psV+Rc/s0NPm0L/VKg4gnDQyx3V7tjV53D5Z7CqXRiTaVe/R+ZAAJgvtokjbrHcwbXfHdIsX/66dIhOg468q1Ql10ZDe9JjvidN2tFRvGojuf9FY9+qITl0qzQnWR9EU264tl7RuxXc/QNQLyCRKpCJcAmUAxYVuTK9mBZQD+RZy4gtsX2YvyT6QDrLiDLeL9AC7An3MOHVbGUjQj6SUGhRxf/qeCg/hQ6JeCcI2oouZeYPQaDbKaf68xIA5n/gVvFcQy8fGLT/0aY9pCHqhBFzKGSGgkw6/eMTAaIKUop1yd9hGiFpiAC6msMNk5sTNi6yqqEnokgSY7grRkQQ+KE=
-  file: /home/travis/build/zazukoians/LodView/target/lodview.war
+  file: target/lodview.war
   on:
     repo: zazukoians/LodView

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ deploy:
   file: target/lodview.war
   on:
     repo: zazukoians/LodView
+    tags: true
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM tomcat
+MAINTAINER adrian.gschwend@zazuko.com
+
+RUN cd /usr/local/tomcat/webapps/ && \
+    curl -Ls $(curl -s https://api.github.com/repos/zazukoians/LodView/releases | grep browser_download_url | head -n 1 | cut -d '"' -f 4) > lodview.war
+
+CMD ["catalina.sh", "run"]
+EXPOSE 8080 8009


### PR DESCRIPTION
Travis CI to provide binary releases of the war-file. The Github API Secret needs to be adjusted to your own key, see [documentation](https://docs.travis-ci.com/user/deployment/releases/#Authenticating-with-an-Oauth-token) for more information. The command line tool makes this very straight forward.