### PR TITLE
fix dotenv, resolve #69

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>io.github.cdimascio</groupId>
 			<artifactId>dotenv-java</artifactId>
-			<version>2.2.0</version>
+			<version>3.0.0</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
+++ b/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
@@ -18,7 +18,7 @@ import org.apache.jena.rdf.model.NodeIterator;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.ResIterator;
 import org.apache.jena.rdf.model.Resource;
-
+import io.github.cdimascio.dotenv.Dotenv;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +59,7 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 
 	Random rand = new Random();
 	
-	private Dotenv dotenv = Dotenv.load();
+	private Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
 
 	public ConfigurationBean() throws IOException, Exception {
 


### PR DESCRIPTION
This PR fixes two bugs:
* fix the compile error by adding the missing Dotenv import back in
* fix the runtime error when a .env file is not present